### PR TITLE
Abstract implementation for item event creation

### DIFF
--- a/src/Events/ItemSavedEvent.php
+++ b/src/Events/ItemSavedEvent.php
@@ -29,16 +29,16 @@ abstract class ItemSavedEvent
     }
 
     /** @var Item */
-    private $previous;
+    protected $previous;
     /** @var Item */
-    private $current;
+    protected $current;
 
     /**
      * ItemSavedEvent constructor.
      * @param Item $current
      * @param Item $previous
      */
-    private function __construct($current, $previous)
+    protected function __construct($current, $previous)
     {
         $this->current = $current;
         $this->previous = $previous;

--- a/src/Events/ItemSavedEvent.php
+++ b/src/Events/ItemSavedEvent.php
@@ -6,10 +6,27 @@ use SnowIO\DataLakeDataModel\Item;
 abstract class ItemSavedEvent
 {
     public abstract static function fromJson(array $eventJson);
-    public abstract function getCurrent(): ?Item;
-    public abstract function getPrevious(): ?Item;
-    public abstract function hasPrevious(): bool;
-    public abstract function getTimestamp(): bool;
+
+    /**
+     * @return Item
+     */
+    public function getCurrent()
+    {
+        return $this->current;
+    }
+
+    /**
+     * @return Item
+     */
+    public function getPrevious()
+    {
+        return $this->previous;
+    }
+
+    public function hasPrevious(): bool
+    {
+        return $this->previous !== null;
+    }
 
     /** @var Item */
     private $previous;

--- a/src/Events/ItemSavedEvent.php
+++ b/src/Events/ItemSavedEvent.php
@@ -33,7 +33,12 @@ abstract class ItemSavedEvent
     /** @var Item */
     private $current;
 
-    private function __construct(Item $current, Item $previous)
+    /**
+     * ItemSavedEvent constructor.
+     * @param Item $current
+     * @param Item $previous
+     */
+    private function __construct($current, $previous)
     {
         $this->current = $current;
         $this->previous = $previous;

--- a/src/Events/ItemSavedEvent.php
+++ b/src/Events/ItemSavedEvent.php
@@ -16,7 +16,7 @@ abstract class ItemSavedEvent
     /** @var Item */
     private $current;
 
-    public function __construct(Item $current, Item $previous)
+    private function __construct(Item $current, Item $previous)
     {
         $this->current = $current;
         $this->previous = $previous;

--- a/src/Events/ItemSavedEvent.php
+++ b/src/Events/ItemSavedEvent.php
@@ -1,0 +1,24 @@
+<?php
+namespace SnowIO\DataLakeDataModel\Events;
+
+use SnowIO\DataLakeDataModel\Item;
+
+abstract class ItemSavedEvent
+{
+    public abstract static function fromJson(array $eventJson);
+    public abstract function getCurrent(): ?Item;
+    public abstract function getPrevious(): ?Item;
+    public abstract function hasPrevious(): bool;
+    public abstract function getTimestamp(): bool;
+
+    /** @var Item */
+    private $previous;
+    /** @var Item */
+    private $current;
+
+    public function __construct(Item $current, Item $previous)
+    {
+        $this->current = $current;
+        $this->previous = $previous;
+    }
+}

--- a/src/ItemSavedEventFactory.php
+++ b/src/ItemSavedEventFactory.php
@@ -1,9 +1,7 @@
 <?php
 namespace SnowIO\DataLakeDataModel;
 
-use SnowIO\DataLakeDataModel\Events\ItemSavedEvent;
-
 interface ItemSavedEventFactory
 {
-    public function createItemSavedEvent(array $input): ItemSavedEvent;
+    public function createItemSavedEvent(array $input);
 }

--- a/src/ItemSavedEventFactory.php
+++ b/src/ItemSavedEventFactory.php
@@ -1,0 +1,9 @@
+<?php
+namespace SnowIO\DataLakeDataModel;
+
+use SnowIO\DataLakeDataModel\Events\ItemSavedEvent;
+
+interface ItemSavedEventFactory
+{
+    public function createItemSavedEvent(array $input): ItemSavedEvent;
+}

--- a/src/ItemSavedEventFactory.php
+++ b/src/ItemSavedEventFactory.php
@@ -3,5 +3,5 @@ namespace SnowIO\DataLakeDataModel;
 
 interface ItemSavedEventFactory
 {
-    public function createItemSavedEvent(array $input);
+    public function create(array $input);
 }


### PR DESCRIPTION
## Overview

We need to ensure that item events are abstracted as datalake allows for an abitrary variation of items. This is done buy implementation of an abstract factory for item saved event creation. 